### PR TITLE
chore(nvim): update coc.nvim and cspell configurations

### DIFF
--- a/dot_config/nvim/coc-settings.json
+++ b/dot_config/nvim/coc-settings.json
@@ -1,7 +1,11 @@
 {
+    "inlayHint.display": true,
+    "inlayHint.enable": true,
+    "semanticTokens.enable": true,
     "Lua.diagnostics.globals": [
         "vim"
     ],
+    "inlayHint.position": "eol",
     "coc.preferences.currentFunctionSymbolAutoUpdate": true,
     "coc.preferences.formatOnSave": true,
     "coc.source.tag.filetypes": [
@@ -25,7 +29,7 @@
     "list.previousKeymap": "<C-p>",
     "session.directory": "${env:HOME}/.local/state/vim/sessions",
     "session.restartOnSessionLoad": true,
-    "outline.sortBy": "name",
+    "outline.sortBy": "position",
     "outline.keepWindow": true,
     "suggest.defaultSortMethod": "alphabetical",
     "suggest.selection": "recentlyUsedByPrefix",
@@ -66,15 +70,13 @@
     "dialog.rounded": false,
     "explorer.file.showHiddenFiles": true,
     "extensions.updateCheck": "daily",
-    "git.addGBlameToVirtualText": true,
+    "git.addGBlameToVirtualText": false,
     "git.addedSign.text": "█",
     "git.changeRemovedSign.text": "█",
     "git.changedSign.text": "█",
     "git.removedSign.text": "█",
     "git.signPriority": 0,
     "git.topRemovedSign.text": "█",
-    "inlayHint.enable": true,
-    "inlayHint.position": "eol",
     "cSpell.allowCompoundWords": true,
     "cSpell.ignorePaths": [
         "node_modules",
@@ -87,7 +89,9 @@
         "**/*.dll",
         "**/vendor",
         "**/vendor/**",
-        "vendor/**"
+        "vendor/**",
+        "${env:HOME}/.cargo/**",
+        "${env:HOME}/.rustup/**"
     ],
     "cSpell.enabledLanguageIds": [
         "asciidoc",
@@ -139,7 +143,10 @@
     },
     "rust-analyzer.check.command": "clippy",
     "cSpell.userWords": [
+        "KHTML",
+        "bufwtr",
         "byobu",
+        "gitui",
         "jessun",
         "nvim",
         "tmuxinator"

--- a/dot_config/nvim/dicts/personal
+++ b/dot_config/nvim/dicts/personal
@@ -1,0 +1,4 @@
+clippy
+ctags
+gopls
+struct


### PR DESCRIPTION
Enable inlay hints and semantic tokens.
Adjust outline sorting to position and disable git blame virtual text. Update cspell ignore paths for Rust toolchains and add new user words. Introduce a personal dictionary for cspell.