### PR TITLE
feat(git): add dm alias to delete merged branches

### DIFF
--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -10,10 +10,12 @@
     find-merge           = "!sh -c 'commit=$0 && branch=${1:-HEAD} && (git rev-list $commit..$branch --ancestry-path | cat -n; git rev-list $commit..$branch --first-parent | cat -n) | sort -k2 -s | uniq -f1 -d | sort -n | tail -1 | cut -f2'"
     show-merge           = "!sh -c 'merge=$(git find-merge $0 $1) && [ -n \"$merge\" ] && git show $merge'"
     copy-branch-name     = "!sh -c 'echo `git rev-parse --abbrev-ref HEAD` | pbcopy' > /dev/null || return && exit 0"
+    dm                   = "!git branch --merged | grep -v '\\*' | grep -v 'main' | xargs -n 1 git branch -d"
+
     proxy-clean          = !git config --global http.proxy '' && git config --global https.proxy ''
     proxy-enable         = !git config --global http.proxy '{{ .http_proxy }}' && git config --global https.proxy '{{ .https_proxy }}'
     proxy-socks5-enable  = !git config --global http.proxy '{{ .socks5_proxy }}' && git config --global https.proxy '{{ .socks5_proxy }}'
-    delete-merged-branch = "!sh -c 'git branch --merged | xargs git branch -d' "
+
 [core]
     editor         = "nvim"
     quotepath      = false


### PR DESCRIPTION
The new `dm` alias deletes all merged branches,
excluding the current branch and 'main'.
It replaces the less specific `delete-merged-branch` alias.