### PR TITLE
refactor(nvim): move personal spellcheck words

### DIFF
--- a/dot_config/nvim/coc-settings.json
+++ b/dot_config/nvim/coc-settings.json
@@ -142,13 +142,5 @@
         "staticcheck": true
     },
     "rust-analyzer.check.command": "clippy",
-    "cSpell.userWords": [
-        "KHTML",
-        "bufwtr",
-        "byobu",
-        "gitui",
-        "jessun",
-        "nvim",
-        "tmuxinator"
-    ]
+    "cSpell.userWords": []
 }

--- a/dot_config/nvim/dicts/personal
+++ b/dot_config/nvim/dicts/personal
@@ -1,4 +1,11 @@
+KHTML
+bufwtr
+byobu
 clippy
 ctags
+gitui
 gopls
+jessun
+nvim
 struct
+tmuxinator


### PR DESCRIPTION
Relocate custom spellcheck dictionary words from `coc-settings.json` to `dicts/personal` for better organization.